### PR TITLE
add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,9 @@
   "license": "MIT",
   "dependencies": {
     "cli": "^0.6.5"
+  },
+  "repository": {
+    "type" : "git",
+    "url" : "http://github.com/keithamus/hashmark.git"
   }
 }


### PR DESCRIPTION
This gets rid of the npm warning about missing repository field and adds links to this repo on npmjs.com.