### PR TITLE
Add --cwd <directory> option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ flag. It will still be logged to stdout unless you pass `--silent`
 ./bin/hashmark -l 4 file.js 'dist/{hash}.js' --asset-map assets.json
 ```
 
+You can specify from which directory to work from with `--cwd` or `-c`. _Note:_ `asset-map` will be relative to this directory.
+
+```bash
+mkdir dist/subdir
+echo 'abracadabra' > dist/subdir/file.js
+./bin/hashmark --cwd dist -d md5 -l 8 '**/*.js' '{dir}/{name}-{hash}{ext}'
+> {"subdir/file.js":"subdir/file-97640ef5.js"}
+```
+
 ### Programmatically
 
 The hashmark function can be used programmatically. You can pass it a String,

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ echo 'abracadabra' > dist/subdir/file.js
 > {"subdir/file.js":"subdir/file-97640ef5.js"}
 ```
 
+### Integrations
+
+**[replaceinfiles](https://github.com/songkick/replaceinfiles)**
+
+Now that your assets have been renamed, you might want to update references to them in some other files _(ex:background image reference in your css files)_. That's exactly what `replaceinfiles` is made for. Just pipe it to `hashmark`. _It just work™._ [Full example](https://github.com/songkick/replaceinfiles/tree/master/examples/hashmark).
+
 ### Programmatically
 
 The hashmark function can be used programmatically. You can pass it a String,

--- a/bin/hashmark
+++ b/bin/hashmark
@@ -3,6 +3,7 @@
 var cli = require('cli');
 var fs = require('fs');
 var hash = require('..');
+var path = require('path');
 
 cli
     .enable('version', 'autocomplete', 'help', 'glob')
@@ -14,6 +15,12 @@ cli
             'Digest Type (e.g. md5, sha1, sha256, sha512)',
             'string',
             'sha256'
+        ],
+        cwd: [
+            'c',
+            'Resolve path names from this directory',
+            'string',
+            '.'
         ],
         length: [
             'l',
@@ -57,7 +64,7 @@ if (!cli.args.length) {
     }
     if (cli.args.length) {
         files = cli.args.reduce(function(files, pattern) {
-            return files.concat(cli.glob.sync(pattern));
+            return files.concat(cli.glob.sync(path.join(cli.options.cwd, pattern)));
         }, []);
     }
     hash(files, cli.options).on('end', function (map) {

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ module.exports = function hashmark(contents, options, callback) {
         stream.pipe(hash, { end: false });
     });
     return mapEvents.on('file', function (fileName, newFileName) {
-        map[fileName] = newFileName;
+        map[path.relative(options.cwd, fileName)] = path.relative(options.cwd, newFileName);
         fileCount--;
         if (fileCount === 0) {
             mapEvents.emit('end', map);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test12": "echo Test1 | ./bin/hashmark -l 4 -n test.js '{name}-{hash}{ext}' && rm test-7e5e.js",
     "test13": "echo abracadabra > test.js && ./bin/hashmark -d md5 -l 8 -r test.js '{name}-{hash}{ext}' && test ! -f test.js && rm test-97640ef5.js",
     "test14": "mkdir -p testdir/sub && echo Test1 > testdir/sub/test.js && echo Test2 > test2.js && ./bin/hashmark -d md5 -l 4 'testdir/**/*.js' 'test*.js' '{name}-{hash}{ext}' && rm testdir/sub/test.js test2.js test-fa02.js test2-856b.js && rmdir -p testdir/sub",
-    "test": "for i in {1..14}; do npm run test$i; done"
+    "test15": "mkdir -p testdir/sub && echo Test1 > testdir/sub/test.js && echo Test2 > testdir/sub/test2.js && ./bin/hashmark -d md5 -l 4 --cwd 'testdir' 'sub/*.js' '{dir}/{name}-{hash}{ext}' && rm testdir/sub/test.js testdir/sub/test2.js testdir/sub/test-fa02.js testdir/sub/test2-856b.js && rmdir -p testdir/sub",
+    "test": "for i in {1..15}; do npm run test$i; done"
   },
   "author": "Keith Cirkel (http://keithcirkel.co.uk)",
   "license": "MIT",


### PR DESCRIPTION
This adds the ability to specify a current working directory. 

Files are resolved from this path and `asset-map` is clear from it.

Usage (as added to README):

```bash
mkdir dist/subdir
echo 'abracadabra' > dist/subdir/file.js
./bin/hashmark --cwd dist -d md5 -l 8 '**/*.js'
'{dir}/{name}-{hash}{ext}'
> {"subdir/file.js":"subdir/file-97640ef5.js"}
```

The common use case is when the output is actually used. I wrote [an utility](https://www.npmjs.com/package/replaceinfiles) that leverages `hashmark` `asset-map` output to replace references to hashmarked files. I need the output path to be cleared of eventual base directory. If I have:

```bash
tree dist
>
dist
├── assets
│   └── images
│       ├── background.png
│       └── icon.png
└── style.css
```

Where `style.css` references images with stuff like `url(assets/images/background.png)`.

I could use: `hashmark 'dist/**/*.png' '{dir}/{name}-{hash}{ext}'` to hash images. Unfortunately, the output would be something like:

```json
{
  "dist/assets/images/background.png":"dist/assets/images/bacgkround-<hash>.png",
  "dist/assets/images/icon.png":"dist/assets/images/icon-<hash>.png"
}
```

The issue with above output is that I can't really use it to replace references to the images in my `style.css` because `dist/` is present in all paths.

With this PR merged, I can use `hashmark --cwd dist '**/*.png' '{dir}/{name}-{hash}{ext}'` while hashing the images so the output doesn't contain `dist/` and can be used to replace references in `style.css`:

```json
{
  "assets/images/background.png":"assets/images/bacgkround-<hash>.png",
  "assets/images/icon.png":"assets/images/icon-<hash>.png"
}
```

This does not impact existing behaviour as default `cwd` is `.`.