### PR TITLE
Refactor `parseFilePattern`and add 'key' and 'root' keys to pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ hashed versions of each:
 ./bin/hashmark path/to/{filea,fileb,filec}.js 'dist/{name}.{hash}.js'
 ./bin/hashmark **/*.js 'dist/{dir}/{name}.{hash}.js'
 ./bin/hashmark **/*.{js,css} 'dist/{dir}/{name}.{hash}{ext}'
+./bin/hashmark **/*.{js,css} 'dist/{dir}/{hash}-{base}'
 ```
 
 The above even works in shells that do not support globs (such as cmd.exe on
@@ -40,6 +41,8 @@ version 4), the shell will interpret `**` as two `*` in a row, which means that
 hashmark never receives the `**` and therefore cannot expand it. In that case
 you need to quote your argument. Therefore, if you want to write cross-platform
 scripts it is best to always quote the args:
+
+Available pattern keys includes all the keys returned by [`path.parse(filename)`](https://nodejs.org/api/path.html#path_path_parse_pathstring) and `hash` (ie: `hash`, `root`, `dir`, `name`, `base`, `ext`).
 
 ```bash
 ./bin/hashmark 'dir/**/*.{js,css}' 'test/*.js' 'dist/{dir}/{name}.{hash}{ext}'

--- a/index.js
+++ b/index.js
@@ -5,15 +5,16 @@ var EventEmitter = require('events').EventEmitter;
 var fs = require('fs');
 var path = require('path');
 
+var PATTERN_KEYS = Object.keys(path.parse('')).concat('hash');
+
 function parseFilePattern(pattern, fileName, hash) {
     pattern = pattern || '';
     fileName = fileName || '';
-    var ext = path.extname(fileName);
-    return pattern
-        .replace('{dir}', path.dirname(fileName))
-        .replace('{hash}', hash)
-        .replace('{name}', path.basename(fileName, ext))
-        .replace('{ext}', ext);
+    var values = path.parse(fileName);
+    values.hash = hash;
+    return PATTERN_KEYS.reduce(function(newFilePath, key) {
+      return newFilePath.replace('{' + key + '}', values[key]);
+    }, pattern);
 }
 
 module.exports = function hashmark(contents, options, callback) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "hashmark": "./bin/hashmark"
   },
+  "engines": {
+    "node": ">0.10"
+  },
   "scripts": {
     "test1": "echo Foo | ./bin/hashmark 'test.{hash}.js' && rm test.3eae1599bb7f187b86d6427942d172ba8dd7ee5962aab03e0839ad9d59c37eb0.js",
     "test2": "echo Foo | ./bin/hashmark -l 8 'test.{hash}.js' && rm test.3eae1599.js",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test13": "echo abracadabra > test.js && ./bin/hashmark -d md5 -l 8 -r test.js '{name}-{hash}{ext}' && test ! -f test.js && rm test-97640ef5.js",
     "test14": "mkdir -p testdir/sub && echo Test1 > testdir/sub/test.js && echo Test2 > test2.js && ./bin/hashmark -d md5 -l 4 'testdir/**/*.js' 'test*.js' '{name}-{hash}{ext}' && rm testdir/sub/test.js test2.js test-fa02.js test2-856b.js && rmdir -p testdir/sub",
     "test15": "mkdir -p testdir/sub && echo Test1 > testdir/sub/test.js && echo Test2 > testdir/sub/test2.js && ./bin/hashmark -d md5 -l 4 --cwd 'testdir' 'sub/*.js' '{dir}/{name}-{hash}{ext}' && rm testdir/sub/test.js testdir/sub/test2.js testdir/sub/test-fa02.js testdir/sub/test2-856b.js && rmdir -p testdir/sub",
-    "test": "for i in $(seq 1 15); do npm run test$i; done"
+    "test16": "echo Foo > test.js && ./bin/hashmark -d md5 -l 8 test.js '{hash}-{base}' && rm test.js cbd8f798-test.js",
+    "test": "for i in $(seq 1 16); do npm run test$i; done"
   },
   "author": "Keith Cirkel (http://keithcirkel.co.uk)",
   "license": "MIT",


### PR DESCRIPTION
While adding the `--cwd` options, I noticed the `parseFilePattern` function could be made more generic by using `path.parse(filePath)` to get values such as `dir`, `base`, `name` instead of various specific methods.

The already available pattern keys, luckily, were already matching `path.parse` result keys, which means this doesn't break existing API.

As a bonus, it brings two new values:

* `{base}` which is equivalent to `{name}{ext}`
* `{root}` which would otherwise be completely unavailable. I don't even know how to get it out of a `path.parse` result (see [source](https://github.com/nodejs/node/blob/master/lib/path.js#L593)).

I'm not sure if it's useful but it comes for free.

Just a quick proof that the two are equivalent, the following snipets just works:

```js
var path = require('path');
var assert = require('assert');

function testPath(filePath, root) {
  // using `path.parse`
  var auto = path.parse(filePath);

  // using individual methods
  var ext = path.extname(filePath);
  var name = path.basename(filePath, ext);
  var base = path.basename(filePath);
  var dir = path.dirname(filePath);

  var manual = {
    ext,
    name,
    base,
    dir,
    root,
  };

  assert.deepEqual(auto, manual);
}

testPath('/path/to/some-file.txt', '/');
testPath('./path/to/some-file.txt', '');

console.log('YAY!');
```

Finally, available pattern keys documentation and tests have been added.