### PR TITLE
Add travis configuration and flag on README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "0.12"
+  - "4.2"
+  - "stable"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HashMark
 
+[![Build Status](https://travis-ci.org/keithamus/hashmark.svg)](https://travis-ci.org/keithamus/hashmark)
+
 HashMark is a small utility which takes a file (or sdtin) as input, and writes
 the contents of the input to a file named with a hash digest of the file. This
 is useful for cache busting sticky caches - files can have far future expires


### PR DESCRIPTION
Travis config will test on current LTS except 0.10 (0.12, 4.2) and current stable.

You'll need to enable travis on [https://travis-ci.org](https://travis-ci.org)