### PR TITLE
normalizing output file paths

### DIFF
--- a/bin/hashmark
+++ b/bin/hashmark
@@ -83,5 +83,6 @@ if (!cli.args.length) {
                 }, map);
             }
             fs.writeFileSync(assetMapPath, JSON.stringify(map, null, 2).replace(/\\\\/g,'/'));
+        }
     });
 }

--- a/bin/hashmark
+++ b/bin/hashmark
@@ -80,7 +80,7 @@ if (!cli.args.length) {
                     return map;
                 }, map);
             }
-            fs.writeFileSync(cli.options['asset-map'], JSON.stringify(map, null, 2));
+            fs.writeFileSync(cli.options['asset-map'], JSON.stringify(map, null, 2).replace(/\\\\/g,'/'));
         }
     });
 }


### PR DESCRIPTION
`{"dir\\dir\\file.png": "dir\\dir\\file-junk.png"}` is not very useful when everything else in the world uses `/`, such as the URLs typed into files which replaceinfile uses to match and replace references.
This is a sort of opinionated change as "should this module be responsible for doing this".... but let's just call it "normalizing output file paths".

Replaces `\\` with `/`. since windows <s>sucks</s>... exists.