### PR TITLE
Fix output path when using cwd option

### DIFF
--- a/bin/hashmark
+++ b/bin/hashmark
@@ -69,18 +69,20 @@ if (!cli.args.length) {
     }
     hash(files, cli.options).on('end', function (map) {
         // Output hash
+        var assetMapPath = cli.options['asset-map'];
         if (!cli.options.silent) {
             process.stdout.write(JSON.stringify(map));
         }
-        if (cli.options['asset-map']) {
+        if (assetMapPath) {
+            assetMapPath = path.join(cli.options.cwd, assetMapPath);
             if (fs.existsSync(cli.options['asset-map'])) {
-                var assetMap = JSON.parse(fs.readFileSync(cli.options['asset-map']));
+                var assetMap = JSON.parse(fs.readFileSync(assetMapPath));
                 Object.keys(assetMap).reduce(function (map, key) {
                     map[key] = map[key] || assetMap[key];
                     return map;
                 }, map);
             }
-            fs.writeFileSync(cli.options['asset-map'], JSON.stringify(map, null, 2));
+            fs.writeFileSync(assetMapPath, JSON.stringify(map, null, 2));
         }
     });
 }

--- a/index.js
+++ b/index.js
@@ -7,10 +7,11 @@ var path = require('path');
 
 var PATTERN_KEYS = Object.keys(path.parse('')).concat('hash');
 
-function parseFilePattern(pattern, fileName, hash) {
+function parseFilePattern(pattern, fileName, cwd, hash) {
     pattern = pattern || '';
     fileName = fileName || '';
     var values = path.parse(fileName);
+    values.dir = path.relative(cwd, values.dir);
     values.hash = hash;
     return PATTERN_KEYS.reduce(function(newFilePath, key) {
       return newFilePath.replace('{' + key + '}', values[key]);
@@ -69,7 +70,8 @@ module.exports = function hashmark(contents, options, callback) {
                 digest = digest.slice(0, options.length);
             }
             if (options.pattern) {
-                var fileName = parseFilePattern(options.pattern, stream.fileName, digest);
+                var fileName = path.resolve(options.cwd,
+                    parseFilePattern(options.pattern, stream.fileName, options.cwd, digest));
 
                 if (options.rename === true ) {
                     fs.rename(stream.fileName, fileName, function (err) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "test15": "mkdir -p testdir/sub && echo Test1 > testdir/sub/test.js && echo Test2 > testdir/sub/test2.js && ./bin/hashmark -d md5 -l 4 --cwd 'testdir' 'sub/*.js' '{dir}/{name}-{hash}{ext}' && rm testdir/sub/test.js testdir/sub/test2.js testdir/sub/test-fa02.js testdir/sub/test2-856b.js && rmdir -p testdir/sub",
     "test16": "echo Foo > test.js && ./bin/hashmark -d md5 -l 8 test.js '{hash}-{base}' && rm test.js cbd8f798-test.js",
     "test17": "mkdir -p testdir/sub/nested && echo Test1 > testdir/sub/test.js && echo Test2 > testdir/sub/test2.js && ./bin/hashmark -d md5 -l 4 --cwd 'testdir' 'sub/*' '{dir}/{name}-{hash}{ext}' && rm testdir/sub/test.js testdir/sub/test2.js testdir/sub/test-fa02.js testdir/sub/test2-856b.js && rmdir -p testdir/sub/nested",
-    "test": "for i in $(seq 1 17); do npm run test$i; done"
+    "test18": "mkdir -p testdir/sub && echo 'Test --cwd without {dir} in pattern' > testdir/sub/test.js && echo Test2 > testdir/sub/test2.js && ./bin/hashmark -d md5 -l 4 --cwd 'testdir/sub' '*' '{name}-{hash}{ext}' && rm testdir/sub/test.js testdir/sub/test2.js testdir/sub/test-84c5.js testdir/sub/test2-856b.js && rmdir -p testdir/sub",
+    "test19": "mkdir -p testdir/sub && echo 'Test --cwd and --asset-map' > testdir/sub/test.js && ./bin/hashmark -l 4 --cwd 'testdir/sub' --asset-map assets.json '*' '{name}-{hash}{ext}' && (grep -e '\"test\\.js\":\\s*\"test-7068.js\"' testdir/sub/assets.json || (echo '\nWrong content in asset-map file' 1>&2; exit 1)) && rm testdir/sub/assets.json && rm -rf testdir",
+    "test": "for i in $(seq 1 19); do rm -rf testdir; npm run test$i; done"
   },
   "author": "Keith Cirkel (http://keithcirkel.co.uk)",
   "license": "MIT",


### PR DESCRIPTION
When using option `-cwd target/foo/bar` the ouput files where written to actual current working directory. Not the one specified with the cwd option.

The output also included `../../../` for the hased files:

```
{ 'controllers.js': '../../../controllers-cc055.js',
  'services.js': '../../../services-3610e.js',
  'vendor.js': '../../../vendor-42243.js',
  'main.js': '../../../main-6aaad.js' }
```

This PR fixes the output files, by also respecting the `cwd` options for the output filename. So now the files are written relative to the `cwd` option, and the output is correct:

```
{ 'controllers.js': 'controllers-cc055.js',
  'services.js': 'services-3610e.js',
  'vendor.js': 'vendor-42243.js',
  'main.js': 'main-6aaad.js' }
```