### PR TITLE
Fix CWD handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ echo 'abracadabra' > dist/subdir/file.js
 > {"subdir/file.js":"subdir/file-97640ef5.js"}
 ```
 
+You can specify the source base folder with `--src-base`, or `-b`. It can be useful to
+
+```bash
+mkdir -p src/images/image1.png
+echo 'abracadabra' > src/images/image1.png
+./bin/hashmark --src-base src -d md5 -l 8 'images/**' 'dist/{dir}/{name}-{hash}{ext}'
+> {"src/images/image1.png":"dist/images/image1-97640ef5.png"}
+```
+
 ### Integrations
 
 **[replaceinfiles](https://github.com/songkick/replaceinfiles)**

--- a/bin/hashmark
+++ b/bin/hashmark
@@ -22,6 +22,12 @@ cli
             'string',
             '.'
         ],
+        'src-base': [
+            'b',
+            'Base path for source files',
+            'string',
+            '.'
+        ],
         length: [
             'l',
             'Limit the digest to this many characters (0 for unlimited)',
@@ -64,8 +70,10 @@ if (!cli.args.length) {
     }
     if (cli.args.length) {
         files = cli.args.reduce(function(files, pattern) {
-            return files.concat(cli.glob.sync(path.join(cli.options.cwd, pattern)));
-        }, []);
+            return files.concat(cli.glob.sync(path.join(cli.options.cwd, cli.options['src-base'], pattern)));
+        }, []).filter(function(filePath){
+          return fs.lstatSync(filePath).isFile();
+        });
     }
     hash(files, cli.options).on('end', function (map) {
         // Output hash

--- a/index.js
+++ b/index.js
@@ -4,13 +4,16 @@ var crypto = require('crypto');
 var EventEmitter = require('events').EventEmitter;
 var fs = require('fs');
 var path = require('path');
+var mkdirp = require('mkdirp');
 
 var PATTERN_KEYS = Object.keys(path.parse('')).concat('hash');
 
-function parseFilePattern(pattern, fileName, hash) {
-    pattern = pattern || '';
+function parseFilePattern(options, fileName, hash, cwd) {
+    var pattern = options.pattern || '';
+    var cwd = options.cwd || './';
     fileName = fileName || '';
-    var values = path.parse(fileName);
+    var resolved = path.relative(cwd, fileName);
+    var values = path.parse(resolved);
     values.hash = hash;
     return PATTERN_KEYS.reduce(function(newFilePath, key) {
       return newFilePath.replace('{' + key + '}', values[key]);
@@ -69,24 +72,26 @@ module.exports = function hashmark(contents, options, callback) {
                 digest = digest.slice(0, options.length);
             }
             if (options.pattern) {
-                var fileName = parseFilePattern(options.pattern, stream.fileName, digest);
+                var fileName = parseFilePattern(options, stream.fileName, digest);
+                var distName = path.parse(fileName).dir;
 
-                if (options.rename === true ) {
-                    fs.rename(stream.fileName, fileName, function (err) {
-                        if (err) {
-                            return mapEvents.emit('error', err);
-                        }
-                        mapEvents.emit('file', stream.fileName, fileName);
-                    });
-                } else {
-                    fs.writeFile(fileName, contents, function (err) {
-                        if (err) {
-                            return mapEvents.emit('error', err);
-                        }
-                        mapEvents.emit('file', stream.fileName, fileName);
-                    });
-                }
-
+                mkdirp(distName, function(){
+                  if (options.rename === true ) {
+                      fs.rename(stream.fileName, fileName, function (err) {
+                          if (err) {
+                              return mapEvents.emit('error', err);
+                          }
+                          mapEvents.emit('file', stream.fileName, fileName);
+                      });
+                  } else {
+                      fs.writeFile(fileName, contents, function (err) {
+                          if (err) {
+                              return mapEvents.emit('error', err);
+                          }
+                          mapEvents.emit('file', stream.fileName, fileName);
+                      });
+                  }
+                })
             } else {
                 mapEvents.emit('file', stream.fileName, digest);
             }

--- a/index.js
+++ b/index.js
@@ -11,8 +11,9 @@ var PATTERN_KEYS = Object.keys(path.parse('')).concat('hash');
 function parseFilePattern(options, fileName, hash, cwd) {
     var pattern = options.pattern || '';
     var cwd = options.cwd || './';
+    var srcPath = options['src-base'] || './';
     fileName = fileName || '';
-    var resolved = path.relative(cwd, fileName);
+    var resolved = path.relative(cwd, path.relative(srcPath, fileName));
     var values = path.parse(resolved);
     values.hash = hash;
     return PATTERN_KEYS.reduce(function(newFilePath, key) {
@@ -74,7 +75,6 @@ module.exports = function hashmark(contents, options, callback) {
             if (options.pattern) {
                 var fileName = parseFilePattern(options, stream.fileName, digest);
                 var distName = path.parse(fileName).dir;
-
                 mkdirp(distName, function(){
                   if (options.rename === true ) {
                       fs.rename(stream.fileName, fileName, function (err) {

--- a/package.json
+++ b/package.json
@@ -24,15 +24,16 @@
     "test12": "echo Test1 | ./bin/hashmark -l 4 -n test.js '{name}-{hash}{ext}' && rm test-7e5e.js",
     "test13": "echo abracadabra > test.js && ./bin/hashmark -d md5 -l 8 -r test.js '{name}-{hash}{ext}' && test ! -f test.js && rm test-97640ef5.js",
     "test14": "mkdir -p testdir/sub && echo Test1 > testdir/sub/test.js && echo Test2 > test2.js && ./bin/hashmark -d md5 -l 4 'testdir/**/*.js' 'test*.js' '{name}-{hash}{ext}' && rm testdir/sub/test.js test2.js test-fa02.js test2-856b.js && rmdir -p testdir/sub",
-    "test15": "mkdir -p testdir/sub && echo Test1 > testdir/sub/test.js && echo Test2 > testdir/sub/test2.js && ./bin/hashmark -d md5 -l 4 --cwd 'testdir' 'sub/*.js' '{dir}/{name}-{hash}{ext}' && rm testdir/sub/test.js testdir/sub/test2.js testdir/sub/test-fa02.js testdir/sub/test2-856b.js && rmdir -p testdir/sub",
+    "test15": "mkdir -p testdir/sub && echo Test1 > testdir/sub/test.js && echo Test2 > testdir/sub/test2.js && ./bin/hashmark -d md5 -l 4 --cwd 'testdir' 'sub/*.js' '{dir}/{name}-{hash}{ext}' && rm testdir/sub/test.js testdir/sub/test2.js sub/test-fa02.js sub/test2-856b.js && rmdir -p testdir/sub sub",
     "test16": "echo Foo > test.js && ./bin/hashmark -d md5 -l 8 test.js '{hash}-{base}' && rm test.js cbd8f798-test.js",
-    "test17": "mkdir -p testdir/sub/nested && echo Test1 > testdir/sub/test.js && echo Test2 > testdir/sub/test2.js && ./bin/hashmark -d md5 -l 4 --cwd 'testdir' 'sub/*' '{dir}/{name}-{hash}{ext}' && rm testdir/sub/test.js testdir/sub/test2.js testdir/sub/test-fa02.js testdir/sub/test2-856b.js && rmdir -p testdir/sub/nested",
+    "test17": "mkdir -p testdir/sub && echo Test1 > testdir/sub/test.js && echo Test2 > testdir/sub/test2.js && ./bin/hashmark -d md5 -l 4 --cwd 'testdir' 'sub/*' 'otherDir/{dir}/{name}-{hash}{ext}' && rm testdir/sub/test.js testdir/sub/test2.js otherDir/sub/test-fa02.js otherDir/sub/test2-856b.js && rm -rf testdir/sub otherDir",
     "test": "for i in $(seq 1 17); do npm run test$i; done"
   },
   "author": "Keith Cirkel (http://keithcirkel.co.uk)",
   "license": "MIT",
   "dependencies": {
-    "cli": "^0.6.5"
+    "cli": "^0.6.5",
+    "mkdirp": "^0.5.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test14": "mkdir -p testdir/sub && echo Test1 > testdir/sub/test.js && echo Test2 > test2.js && ./bin/hashmark -d md5 -l 4 'testdir/**/*.js' 'test*.js' '{name}-{hash}{ext}' && rm testdir/sub/test.js test2.js test-fa02.js test2-856b.js && rmdir -p testdir/sub",
     "test15": "mkdir -p testdir/sub && echo Test1 > testdir/sub/test.js && echo Test2 > testdir/sub/test2.js && ./bin/hashmark -d md5 -l 4 --cwd 'testdir' 'sub/*.js' '{dir}/{name}-{hash}{ext}' && rm testdir/sub/test.js testdir/sub/test2.js sub/test-fa02.js sub/test2-856b.js && rmdir -p testdir/sub sub",
     "test16": "echo Foo > test.js && ./bin/hashmark -d md5 -l 8 test.js '{hash}-{base}' && rm test.js cbd8f798-test.js",
-    "test17": "mkdir -p testdir/sub && echo Test1 > testdir/sub/test.js && echo Test2 > testdir/sub/test2.js && ./bin/hashmark -d md5 -l 4 --cwd 'testdir' 'sub/*' 'otherDir/{dir}/{name}-{hash}{ext}' && rm testdir/sub/test.js testdir/sub/test2.js otherDir/sub/test-fa02.js otherDir/sub/test2-856b.js && rm -rf testdir/sub otherDir",
+    "test17": "mkdir -p testdir/sub && echo Test1 > testdir/sub/test.js && echo Test2 > testdir/sub/test2.js && ./bin/hashmark -d md5 -l 4 --cwd 'testdir' 'sub/*' 'otherDir/{dir}/{name}-{hash}{ext}' && rm testdir/sub/test.js testdir/sub/test2.js otherDir/sub/test-fa02.js otherDir/sub/test2-856b.js && rm -rf testdir otherDir",
+    "test18": "mkdir -p src/assets/images && echo Test1 > src/assets/images/img1.png && echo Test2 > src/assets/images/img2.png && ./bin/hashmark -d md5 -l 4 --src-base 'src' 'assets/**' 'dist/{dir}/{name}-{hash}{ext}' && rm src/assets/images/img1.png src/assets/images/img2.png dist/assets/images/img1-fa02.png dist/assets/images/img2-856b.png && rm -rf src dist",
     "test": "for i in $(seq 1 17); do npm run test$i; done"
   },
   "author": "Keith Cirkel (http://keithcirkel.co.uk)",


### PR DESCRIPTION
In the current version, CWD implementation has two issues:

1. Target directory is not necessarilly created
1. Target directory is always nested in CWD

Point 1 is an obvious problem.
Point 2 means that we can't run something like (or issue#18):

```
hashmark --cwd 'src' 'assets/**.*' 'dist/{dir}/{name}-{hash}{ext}'
```

Where `dist/` basically contains a copy `assets` folder with hashmarked files. In current version, we'd have `dist/src/assets/...` which is wrong.

Fixes #18