### PR TITLE
Introduce hashOnly option that skips writing the file and only outputs map of replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cat file.js | ./bin/hashmark -l 8 'file.{hash}.js' # Writes to test.3eae1599.js
 cat file.js | ./bin/hashmark -l 4 -d md5 'dist/{hash}.js' # Writes to dist/cbd8.js
 > Computed hash: cbd8
 >
-cat file.js | ./bin/hashmark -l 8 -h 'file.{hash}.js' # Does not write to file. Only computes hash. Can be used for query parameter cache busting (file.js?3eae1599)
+cat file.js | ./bin/hashmark -l 8 -h 'file.js?{hash}' # Does not write to file. Only computes hash. Can be used for query parameter cache busting (file.js?3eae1599)
 > Computed hash: 3eae1599
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ cat file.js | ./bin/hashmark -l 8 'file.{hash}.js' # Writes to test.3eae1599.js
 cat file.js | ./bin/hashmark -l 4 -d md5 'dist/{hash}.js' # Writes to dist/cbd8.js
 > Computed hash: cbd8
 >
+cat file.js | ./bin/hashmark -l 8 -h 'file.{hash}.js' # Does not write to file. Only computes hash. Can be used for query parameter cache busting (file.js?3eae1599)
+> Computed hash: 3eae1599
 ```
 
 It is useful to use globs — meaning you can read in many files and it will output

--- a/bin/hashmark
+++ b/bin/hashmark
@@ -52,6 +52,12 @@ cli
             'boolean',
             false
         ],
+        'hashOnly': [
+            'h',
+            'Skip writing files and only output map of replacements',
+            'boolean',
+            false
+        ],
     });
 
 if (!cli.args.length) {

--- a/index.js
+++ b/index.js
@@ -86,12 +86,16 @@ module.exports = function hashmark(contents, options, callback) {
                         if (err) {
                             return mapEvents.emit('error', err);
                         } else {
-                            fs.writeFile(fileName, contents, function (err) {
-                                if (err) {
-                                    return mapEvents.emit('error', err);
-                                }
+                            if (options.hashOnly) {
                                 mapEvents.emit('file', stream.fileName, fileName);
-                            });
+                            } else {
+                                fs.writeFile(fileName, contents, function (err) {
+                                    if (err) {
+                                        return mapEvents.emit('error', err);
+                                    }
+                                    mapEvents.emit('file', stream.fileName, fileName);
+                                });
+                            }
                         }     
                     });
                 }


### PR DESCRIPTION
In a project I am working on, we want to use query parameter based cache busting, and for that purpose we do not need any files to be written. I have introduced a `-h` parameter that can be used as
    
    hashmark -l 8 -h 'file.js?{hash}'